### PR TITLE
UP-2007 Refactoring request id first round

### DIFF
--- a/src/main/scala/com/ubirch/receiver/actors/Dispatcher.scala
+++ b/src/main/scala/com/ubirch/receiver/actors/Dispatcher.scala
@@ -47,8 +47,7 @@ class Dispatcher(handlerCreator: HttpRequestHandlerCreator) extends Actor with D
   override def receive: Receive = {
     case req: RequestData =>
       log.debug(s"received request with requestId [${req.requestId}]")
-      val reqHandler = handlerCreator(context, sender(), req.requestId)
-      reqHandler ! req
+      handlerCreator(context, sender(), req.requestId) ! req
 
     case resp: ResponseData =>
       log.debug(s"responding to requestId [${resp.requestId}]")

--- a/src/main/scala/com/ubirch/receiver/kafka/KafkaListener.scala
+++ b/src/main/scala/com/ubirch/receiver/kafka/KafkaListener.scala
@@ -68,7 +68,7 @@ class KafkaListener(kafkaUrl: String, topics: Seq[String], dispatcher: ActorRef,
 
   private def deliver(rcds: ConsumerRecords[String, Array[Byte]]): Unit = {
     rcds.iterator().forEachRemaining { record =>
-      dispatcher ! ResponseData(record.key(), record.headersScala, record.value())
+      dispatcher ! ResponseData(record.requestIdHeader().orNull, record.headersScala, record.value())
     }
   }
 


### PR DESCRIPTION
Using the request id as part of the key field for a producer record values makes the partitioning of the data to be unbalanced. This PR moves the request id from the key to a header in the record.