### PR TITLE
UP-2254 Removing exception from response and improving pattern matching

### DIFF
--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -41,7 +41,7 @@ akka {
   }
 
   http.server {
-    request-timeout = 30 s
+    request-timeout = 35 s
   }
 
   cluster {


### PR DESCRIPTION
- When an error happens, it would return the message of the exception. I have modified in a way that a better message is returned to the client and the exception is logged with its corresponding requestId
- I have improved the pattern match as to not use instanceOf.