### PR TITLE
Payload as bytes - Parent POM fix - Scala Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,16 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.ubirch.niomon</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
     <artifactId>http</artifactId>
     <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>


### PR DESCRIPTION
UP-1885 Support for payload as bytes for success with requestId
UP-2301 Fix to parent reference.
UP-2302 Fix Scala incompatibility with internal lib. Scala upgrade.