### PR TITLE
Feature/protobuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,10 +184,39 @@
             <version>${mockito.scala.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.thesamet.scalapb</groupId>
+            <artifactId>scalapb-runtime_${scala.major.version}</artifactId>
+            <version>0.9.0-M5</version>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <!-- Add protobuf-maven-plugin and provide ScalaPB as a code generation plugin -->
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <version>3.11.1</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeMavenTypes>transitive</includeMavenTypes>
+                    <outputTargets>
+                        <outputTarget>
+                            <type>scalapb</type>
+                            <outputOptions>grpc</outputOptions> <!-- more scalapb options can be added here -->
+                            <pluginArtifact>com.thesamet.scalapb:protoc-gen-scala:0.9.6:sh:unix</pluginArtifact>
+                        </outputTarget>
+                    </outputTargets>
+                </configuration>
+            </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.6</version>

--- a/src/main/protobuf/actors.proto
+++ b/src/main/protobuf/actors.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package com.ubirch.receiver;
+
+message ResponseData {
+  string requestId = 1;
+  map<string, string> headers = 2;
+  bytes data = 3;
+}

--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -70,7 +70,8 @@ akka {
     allow-java-serialization = off
     provider = "akka.cluster.ClusterActorRefProvider"
     serializers {
-      proto = "com.ubirch.receiver.actors.HttpProtobufSerializer"
+      proto = "akka.remote.serialization.ProtobufSerializer"
+      #proto = "com.ubirch.receiver.actors.HttpProtobufSerializer"
     }
 
     serialization-bindings {

--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -68,6 +68,13 @@ akka {
 
   actor {
     provider = "akka.cluster.ClusterActorRefProvider"
+    serializers {
+      proto = "akka.remote.serialization.ProtobufSerializer"
+    }
+
+    serialization-bindings {
+      "com.ubirch.receiver.ResponseData" = proto
+    }
   }
 
   remote {

--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -67,13 +67,16 @@ akka {
   }
 
   actor {
+    allow-java-serialization = off
     provider = "akka.cluster.ClusterActorRefProvider"
     serializers {
-      proto = "akka.remote.serialization.ProtobufSerializer"
+      proto = "com.ubirch.receiver.actors.HttpProtobufSerializer"
     }
 
     serialization-bindings {
-      "com.ubirch.receiver.ResponseData" = proto
+      "java.io.Serializable" = none
+      "com.google.protobuf.Message" = proto
+      "com.ubirch.receiver.actors.ResponseData" = proto
     }
   }
 

--- a/src/main/resources/application-base.conf
+++ b/src/main/resources/application-base.conf
@@ -71,13 +71,13 @@ akka {
     provider = "akka.cluster.ClusterActorRefProvider"
     serializers {
       proto = "akka.remote.serialization.ProtobufSerializer"
-      #proto = "com.ubirch.receiver.actors.HttpProtobufSerializer"
+      http = "com.ubirch.receiver.actors.HttpProtobufSerializer"
     }
 
     serialization-bindings {
       "java.io.Serializable" = none
       "com.google.protobuf.Message" = proto
-      "com.ubirch.receiver.actors.ResponseData" = proto
+      "com.ubirch.receiver.actors.ResponseData" = http
     }
   }
 

--- a/src/main/scala/com/ubirch/receiver/actors/HttpProtobufSerializer.scala
+++ b/src/main/scala/com/ubirch/receiver/actors/HttpProtobufSerializer.scala
@@ -11,17 +11,12 @@ class HttpProtobufSerializer extends SerializerWithStringManifest{
 
 
   override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
-
-    println("inside fromBinary"+manifest)
-
     manifest match {
       case ResponseDataManifest => ResponseData.parseFrom(bytes)
     }
   }
 
   override def toBinary(o: AnyRef): Array[Byte] = {
-
-    println("inside toBinary ")
     o match {
       case a: ResponseData => a.toByteArray
     }

--- a/src/main/scala/com/ubirch/receiver/actors/HttpProtobufSerializer.scala
+++ b/src/main/scala/com/ubirch/receiver/actors/HttpProtobufSerializer.scala
@@ -1,0 +1,29 @@
+package com.ubirch.receiver.actors
+
+import akka.serialization.SerializerWithStringManifest
+
+class HttpProtobufSerializer extends SerializerWithStringManifest{
+
+  def identifier: Int = 101110116
+
+  override def manifest(o: AnyRef): String = o.getClass.getName
+  final val ResponseDataManifest = classOf[ResponseData].getName
+
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+
+    println("inside fromBinary"+manifest)
+
+    manifest match {
+      case ResponseDataManifest => ResponseData.parseFrom(bytes)
+    }
+  }
+
+  override def toBinary(o: AnyRef): Array[Byte] = {
+
+    println("inside toBinary ")
+    o match {
+      case a: ResponseData => a.toByteArray
+    }
+  }
+}

--- a/src/main/scala/com/ubirch/receiver/actors/HttpRequestHandler.scala
+++ b/src/main/scala/com/ubirch/receiver/actors/HttpRequestHandler.scala
@@ -87,5 +87,3 @@ class HttpRequestHandler(requester: ActorRef, publisher: KafkaPublisher) extends
 }
 
 final case class RequestData(requestId: String, payload: Array[Byte], headers: Map[String, String])
-
-final case class ResponseData(requestId: String, headers: Map[String, String], data: Array[Byte])

--- a/src/main/scala/com/ubirch/receiver/http/HttpServer.scala
+++ b/src/main/scala/com/ubirch/receiver/http/HttpServer.scala
@@ -195,7 +195,7 @@ class HttpServer(port: Int, dispatcher: ActorRef)(implicit val system: ActorSyst
             val code = headers.filterNot(_ => status == StatusCodes.OK).get("x-err")
             responsesSent.labels(status.toString()).inc()
             timer.observeDuration()
-            Success(Right((result.data, status.intValue(), code)))
+            Success(Right((result.data.toByteArray, status.intValue(), code)))
 
           case Success(_) =>
             log.error("dispatcher failure -wrong response type-", v("requestId", requestId))

--- a/src/main/scala/com/ubirch/receiver/kafka/KafkaListener.scala
+++ b/src/main/scala/com/ubirch/receiver/kafka/KafkaListener.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import akka.actor.ActorRef
 import cakesolutions.kafka.KafkaConsumer
 import cakesolutions.kafka.KafkaConsumer.Conf
+import com.google.protobuf.ByteString
 import com.typesafe.scalalogging.Logger
 import com.ubirch.kafka._
 import com.ubirch.niomon.healthcheck.{Checks, HealthCheckServer}
@@ -68,7 +69,7 @@ class KafkaListener(kafkaUrl: String, topics: Seq[String], dispatcher: ActorRef,
 
   private def deliver(rcds: ConsumerRecords[String, Array[Byte]]): Unit = {
     rcds.iterator().forEachRemaining { record =>
-      dispatcher ! ResponseData(record.requestIdHeader().orNull, record.headersScala, record.value())
+      dispatcher ! ResponseData(record.requestIdHeader().orNull, record.headersScala, ByteString.copyFrom(record.value()))
     }
   }
 

--- a/src/test/scala/com/ubirch/receiver/actors/DispatcherTest.scala
+++ b/src/test/scala/com/ubirch/receiver/actors/DispatcherTest.scala
@@ -19,6 +19,7 @@ package com.ubirch.receiver.actors
 import akka.actor.{ActorSystem, Props}
 import akka.serialization.Serialization
 import akka.testkit.TestProbe
+import com.google.protobuf.ByteString
 import com.ubirch.receiver.kafka.KafkaPublisher
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
@@ -49,7 +50,7 @@ class DispatcherTest extends FlatSpec with MockitoSugar with ArgumentMatchersSug
     //given
     val handler = TestProbe()
     val dispatcher = system.actorOf(Props(classOf[Dispatcher], requestHandlerCreator(mock[KafkaPublisher])))
-    val responseData = ResponseData("someId", Map("http-request-handler-actor" -> Serialization.serializedActorPath(handler.ref)), "value".getBytes)
+    val responseData = ResponseData("someId", Map("http-request-handler-actor" -> Serialization.serializedActorPath(handler.ref)), ByteString.copyFrom("value".getBytes()))
 
     // when
     dispatcher ! responseData

--- a/src/test/scala/com/ubirch/receiver/actors/HttpRequestHandlerTest.scala
+++ b/src/test/scala/com/ubirch/receiver/actors/HttpRequestHandlerTest.scala
@@ -23,6 +23,7 @@ import com.ubirch.receiver.kafka.{KafkaPublisher, PublisherException, PublisherS
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import com.google.protobuf.ByteString
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.Future
@@ -54,7 +55,7 @@ class HttpRequestHandlerTest extends FlatSpec with MockitoSugar with ArgumentMat
     //given
     val returnTo = TestProbe()
     val requestHandler = system.actorOf(Props(classOf[HttpRequestHandler], returnTo.ref, mock[KafkaPublisher]))
-    val responseData = ResponseData("requestId", Map(), "value".getBytes)
+    val responseData = ResponseData("requestId", Map(), ByteString.copyFrom("Hola".getBytes()))
 
     // when
     requestHandler ! responseData


### PR DESCRIPTION
Adding support to for the akka cluster to serialize the object ResponseData with Protobuffer as it was serializing with java. Not recommended for its performance.